### PR TITLE
Introduce subcommands and cli argument parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "commander": "^13.1.0",
         "fast-xml-parser": "^4.5.1"
       },
       "devDependencies": {
@@ -890,6 +891,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "vitest": "^3.0.4"
   },
   "dependencies": {
+    "commander": "^13.1.0",
     "fast-xml-parser": "^4.5.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,42 @@
 import * as fs from 'fs';
 import { generateEnumsFromXSD } from './enums';
+import { Command } from 'commander';
 
-// Entry point
-const main = () => {
-  const xsdFilePath = './data/ONIX_BookProduct_CodeLists.xsd'; // Replace with the actual path to the XSD file
-  const outputDir = './data/codelist/output/';
+const program = new Command();
 
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true });
-  }
+program
+  .command('generate-enums')
+  .description('Generate enums from a CodeList file')
+  .requiredOption('-s, --source <source>', 'The source xsd file that contains the CodeLists')
+  .option('-o, --output <output>', 'The output directory where the enums should be saved', './data/codelist/output')
+  .action((options) => {
+    console.log(`Generating enums from ${options.source} in ${options.output}`);
 
-  generateEnumsFromXSD(xsdFilePath, outputDir);
-};
+    if (!fs.existsSync(options.output)) {
+        fs.mkdirSync(options.output, { recursive: true });
+      }
+    
+      generateEnumsFromXSD(options.source, options.output);
 
-main();
+  });
+
+program
+  .command('generate-types')
+  .description('Generate typescript types from a xsd file')
+  .requiredOption('-s, --source <source>', 'The source xsd file that contains the definition of the types')
+  .option('-o, --output <output>', 'The output directory where the types should be saved', './data/types/output')
+  .action((options) => {
+    console.log(`Generating types from ${options.source} in ${options.output}`);
+
+    //TODO: Add type generation code here.
+
+  });
+
+console.log(process.argv);
+
+// Add a global help option and parse the command line arguments
+program
+  .name('onix-type-generator')
+  .description('An CLI tool that allows to generate Typescript types from Onix files.')
+  .version('1.0.0')
+  .parse(process.argv);


### PR DESCRIPTION
In the future this tool is supposed to be able to generate typescript types from an Onix xsd file. In order to distinguish between generating types or generating the enums for the code lists, we are using subcommands. Commander is a typescript package that allows us to introduce subcommands and parsing of command line arguments. This change introduces both, the parsing of command line arguments for the current functionality (generating enums) as well as the introduction of subcommands.